### PR TITLE
Save super-linter output for better understanding of issues it reports

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -38,6 +38,7 @@ jobs:
           VALIDATE_SHELL_SHFMT: false
           VALIDATE_YAML: false
           VALIDATE_YAML_PRETTIER: false
+          SAVE_SUPER_LINTER_OUTPUT: true
           # VALIDATE_DOCKERFILE_HADOLINT: false
           # VALIDATE_MARKDOWN: false
           # VALIDATE_NATURAL_LANGUAGE: false

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ pattern-vault.init
 vault.init
 super-linter.log
 common/pattern-vault.init
+
+# Super-linter outputs
+super-linter-output
+
+# GitHub Actions leftovers
+github_conf

--- a/common/Makefile
+++ b/common/Makefile
@@ -253,6 +253,7 @@ super-linter: ## Runs super linter locally
 					-e VALIDATE_TEKTON=false \
 					-e VALIDATE_YAML=false \
 					-e VALIDATE_YAML_PRETTIER=false \
+					-e SAVE_SUPER_LINTER_OUTPUT=true \
 					$(DISABLE_LINTERS) \
 					-v $(PWD):/tmp/lint:rw,z \
 					-w /tmp/lint \


### PR DESCRIPTION
* Support saving super-linter output for both Makefile and github action to make it clear what has failed when it does