### PR TITLE
Disable operator managed ingress

### DIFF
--- a/charts/keycloak/templates/keycloak.yaml
+++ b/charts/keycloak/templates/keycloak.yaml
@@ -20,7 +20,5 @@ spec:
   http:
     tlsSecret: {{ .Values.keycloak.tls.secret }}
   ingress:
-    {{- if not (eq .Values.keycloak.ingress.enabled true) }}
     enabled: false
-    {{- end }}
   instances: 1


### PR DESCRIPTION
Disable operator managed ingress otherwise the operator attempts to manage the content which causes an error to be displayed in the `Keycloak` CR