### PR TITLE
Updated values-hub.yaml to include app reference to vp-sample-app-chart repo

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -98,6 +98,14 @@ clusterGroup:
       overrides:
         - name: spire.clusterName
           value: hub
+    pchat:
+      name: pchat
+      namespace: pchat
+      project: hub
+      repoURL: https://github.com/posip-redhat/vp-sample-app-chart
+      chartVersion: main
+      path: "."
+
   imperative:
     # NOTE: We *must* use lists and not hashes. As hashes lose ordering once parsed by helm
     # The default schedule is every 10 minutes: imperative.schedule


### PR DESCRIPTION
Using new https://github.com/validatedpatterns/vp-template-chart as a template created https://github.com/posip-redhat/vp-sample-app-chart/tree/main to hold argocd Helm chart configuration for Quarkus based persistent chat application deployed to quay.io/posip-lab/pchat:latest with source code and build instructions at https://github.com/posip-redhat/pchat/tree/main