### PR TITLE
fix: offset all Argo CD sync-wave values by +31 to ensure positive waves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ install: operator-deploy post-install ## installs the pattern and loads the secr
 .PHONY: post-install
 post-install: ## Post-install tasks
 	make load-secrets
+	@echo "Waiting for MachineConfigPool rollout to complete..."
+	oc wait mcp/master --for=condition=Updated --timeout=600s
 	make vault-config-jwt
 	@echo "Done"
 

--- a/charts/acs-central/templates/admin-password-secret.yaml
+++ b/charts/acs-central/templates/admin-password-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/sync-wave: "36"
 type: Opaque
 stringData:
   password: {{ .Values.central.adminPassword.password | default (randAlphaNum 32) | quote }}

--- a/charts/acs-central/templates/central-cr.yaml
+++ b/charts/acs-central/templates/central-cr.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-wave: "41"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   central:

--- a/charts/acs-central/templates/central-htpasswd-external-secret.yaml
+++ b/charts/acs-central/templates/central-htpasswd-external-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/sync-wave: "36"
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/acs-central/templates/console-link.yaml
+++ b/charts/acs-central/templates/console-link.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "15"
+    argocd.argoproj.io/sync-wave: "46"
 spec:
   href: https://central-{{ .Release.Namespace }}.{{ .Values.global.localClusterDomain }}
   location: ApplicationMenu

--- a/charts/acs-central/templates/jobs/create-auth-provider.yaml
+++ b/charts/acs-central/templates/jobs/create-auth-provider.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "13"
+    argocd.argoproj.io/sync-wave: "44"
 spec:
   template:
     metadata:

--- a/charts/acs-central/templates/jobs/create-cluster-init-bundle.yaml
+++ b/charts/acs-central/templates/jobs/create-cluster-init-bundle.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "12"
+    argocd.argoproj.io/sync-wave: "43"
 spec:
   template:
     metadata:

--- a/charts/acs-central/templates/jobs/create-htpasswd-field.yaml
+++ b/charts/acs-central/templates/jobs/create-htpasswd-field.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "6"
+    argocd.argoproj.io/sync-wave: "37"
 spec:
   template:
     metadata:

--- a/charts/acs-central/templates/keycloak-client-secret-external-secret.yaml
+++ b/charts/acs-central/templates/keycloak-client-secret-external-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/sync-wave: "36"
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/acs-central/templates/rbac/cluster-init-clusterrole.yaml
+++ b/charts/acs-central/templates/rbac/cluster-init-clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "32"
 rules:
 - apiGroups: ["console.openshift.io"]
   resources: ["consolelinks"]

--- a/charts/acs-central/templates/rbac/cluster-init-clusterrolebinding.yaml
+++ b/charts/acs-central/templates/rbac/cluster-init-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "32"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/acs-central/templates/rbac/cluster-init-role.yaml
+++ b/charts/acs-central/templates/rbac/cluster-init-role.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "32"
 rules:
   - apiGroups:
       - ""

--- a/charts/acs-central/templates/rbac/cluster-init-rolebinding.yaml
+++ b/charts/acs-central/templates/rbac/cluster-init-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "32"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/acs-central/templates/rbac/cluster-init-serviceaccount.yaml
+++ b/charts/acs-central/templates/rbac/cluster-init-serviceaccount.yaml
@@ -6,4 +6,4 @@ metadata:
   labels:
     {{- include "acs-central.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "32"

--- a/charts/acs-secured-cluster/templates/secured-cluster-cr.yaml
+++ b/charts/acs-secured-cluster/templates/secured-cluster-cr.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "acs-secured-cluster.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "15"
+    argocd.argoproj.io/sync-wave: "46"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterName: {{ .Values.clusterName | default .Values.global.clusterName | quote }}

--- a/charts/noobaa-mcg/templates/bucket-class.yaml
+++ b/charts/noobaa-mcg/templates/bucket-class.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.noobaa.bucketClass.name }}
   namespace: {{ .Values.noobaa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "3"  # Layer 1: Create BucketClass
+    argocd.argoproj.io/sync-wave: "34"  # Layer 1: Create BucketClass
 spec:
   placementPolicy:
     tiers:

--- a/charts/noobaa-mcg/templates/default-backingstore.yaml
+++ b/charts/noobaa-mcg/templates/default-backingstore.yaml
@@ -4,7 +4,7 @@ metadata:
   name: noobaa-default-backing-store
   namespace: {{ .Values.noobaa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "32"
 spec:
   type: pv-pool
   pvPool:

--- a/charts/noobaa-mcg/templates/noobaa-system.yaml
+++ b/charts/noobaa-mcg/templates/noobaa-system.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.noobaa.system.name }}
   namespace: {{ .Values.noobaa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "2"  # Layer 1: Deploy NooBaa System
+    argocd.argoproj.io/sync-wave: "33"  # Layer 1: Deploy NooBaa System
 spec:
   tolerations:
     - key: "node.ocs.openshift.io/storage"

--- a/charts/qtodo/templates/app-deployment.yaml
+++ b/charts/qtodo/templates/app-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: '20'
+    argocd.argoproj.io/sync-wave: '51'
   labels:
     app: qtodo
     ztvp.io/uses-certificates: "true"

--- a/charts/qtodo/templates/app-service.yaml
+++ b/charts/qtodo/templates/app-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: '20'
+    argocd.argoproj.io/sync-wave: '51'
   labels:
     app: qtodo
   name: qtodo

--- a/charts/qtodo/templates/postgresql-service.yaml
+++ b/charts/qtodo/templates/postgresql-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: '10'
+    argocd.argoproj.io/sync-wave: '41'
   labels:
     app: qtodo-db
   name: qtodo-db

--- a/charts/qtodo/templates/postgresql-statefulset.yaml
+++ b/charts/qtodo/templates/postgresql-statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: '10'
+    argocd.argoproj.io/sync-wave: '41'
   labels:
     app: qtodo-db
   name: qtodo-db

--- a/charts/qtodo/templates/qtodo-truststore-config.yaml
+++ b/charts/qtodo/templates/qtodo-truststore-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: qtodo-truststore-java
   namespace: qtodo
   annotations:
-    argocd.argoproj.io/sync-wave: '10'
+    argocd.argoproj.io/sync-wave: '41'
   labels:
     app: qtodo
     app.kubernetes.io/component: truststore-init

--- a/charts/qtodo/templates/truststore-secret-external-secret.yaml
+++ b/charts/qtodo/templates/truststore-secret-external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: qtodo-truststore-secret
   namespace: {{ .Release.Namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: '5'
+    argocd.argoproj.io/sync-wave: '36'
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/rhtas-operator/templates/securesign.yaml
+++ b/charts/rhtas-operator/templates/securesign.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "rhtas-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "15"  # Deploy after namespace and operator
+    argocd.argoproj.io/sync-wave: "46"  # Deploy after namespace and operator
     {{- if .Values.rhtas.monitoring.enabled }}
     rhtas.redhat.com/metrics: "true"
     {{- end }}

--- a/charts/rhtpa-operator/templates/ingress-ca-job.yaml
+++ b/charts/rhtpa-operator/templates/ingress-ca-job.yaml
@@ -6,7 +6,7 @@ metadata:
   name: rhtpa-ingress-ca-extractor
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "31"
     argocd.argoproj.io/hook: PreSync
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +15,7 @@ metadata:
   name: rhtpa-ingress-ca-extractor
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "31"
     argocd.argoproj.io/hook: PreSync
 rules:
 - apiGroups: [""]
@@ -28,7 +28,7 @@ metadata:
   name: rhtpa-ingress-ca-extractor
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "31"
     argocd.argoproj.io/hook: PreSync
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -44,7 +44,7 @@ kind: ClusterRole
 metadata:
   name: rhtpa-ingress-ca-reader
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "31"
     argocd.argoproj.io/hook: PreSync
 rules:
 # Read ingress CA from router secret (default or custom)
@@ -66,7 +66,7 @@ kind: ClusterRoleBinding
 metadata:
   name: rhtpa-ingress-ca-reader-{{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "31"
     argocd.argoproj.io/hook: PreSync
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -83,7 +83,7 @@ metadata:
   name: rhtpa-ingress-ca-extractor
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "33"
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:

--- a/charts/rhtpa-operator/templates/object-bucket-claim.yaml
+++ b/charts/rhtpa-operator/templates/object-bucket-claim.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .Values.rhtpa.objectStorage.objectBucketClaim.name }}
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "5"  # Create OBC after NooBaa system is ready
+    argocd.argoproj.io/sync-wave: "36"  # Create OBC after NooBaa system is ready
 spec:
   generateBucketName: {{ .Values.rhtpa.objectStorage.objectBucketClaim.bucketName }}
   storageClassName: {{ .Values.rhtpa.objectStorage.objectBucketClaim.storageClass }}

--- a/charts/rhtpa-operator/templates/oidc-cli-secret.yaml
+++ b/charts/rhtpa-operator/templates/oidc-cli-secret.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "rhtpa-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "3"  # Create before RHTPA CR
+    argocd.argoproj.io/sync-wave: "34"  # Create before RHTPA CR
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/rhtpa-operator/templates/operator-readiness-check.yaml
+++ b/charts/rhtpa-operator/templates/operator-readiness-check.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "rhtpa-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "40"  # Before CR creation (wave 50)
+    argocd.argoproj.io/sync-wave: "71"  # Before CR creation (wave 81)
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
@@ -59,7 +59,7 @@ metadata:
   labels:
     {{- include "rhtpa-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "40"
+    argocd.argoproj.io/sync-wave: "71"
 placementRef:
   name: placement-policy-rhtpa-operator-ready
   kind: PlacementRule
@@ -77,7 +77,7 @@ metadata:
   labels:
     {{- include "rhtpa-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "40"
+    argocd.argoproj.io/sync-wave: "71"
 spec:
   clusterConditions:
     - status: "True"

--- a/charts/rhtpa-operator/templates/operator-rolebinding.yaml
+++ b/charts/rhtpa-operator/templates/operator-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: rhtpa-operator-job-manager
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"  # Create early, before CR
+    argocd.argoproj.io/sync-wave: "32"  # Create early, before CR
 rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
@@ -30,7 +30,7 @@ metadata:
   name: rhtpa-operator-job-manager
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"  # Create early, before CR
+    argocd.argoproj.io/sync-wave: "32"  # Create early, before CR
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/rhtpa-operator/templates/postgresql-external-secret.yaml
+++ b/charts/rhtpa-operator/templates/postgresql-external-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: rhtpa-db-secret
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: '5'
+    argocd.argoproj.io/sync-wave: '36'
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/rhtpa-operator/templates/postgresql-service.yaml
+++ b/charts/rhtpa-operator/templates/postgresql-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: '10'
+    argocd.argoproj.io/sync-wave: '41'
   labels:
     app: rhtpa-db
   name: rhtpa-db

--- a/charts/rhtpa-operator/templates/postgresql-serviceaccount.yaml
+++ b/charts/rhtpa-operator/templates/postgresql-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: '5'
+    argocd.argoproj.io/sync-wave: '36'
   name: rhtpa-db
   namespace: {{ .Values.rhtpa.namespace }}
 {{- end }}

--- a/charts/rhtpa-operator/templates/postgresql-statefulset.yaml
+++ b/charts/rhtpa-operator/templates/postgresql-statefulset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: '10'
+    argocd.argoproj.io/sync-wave: '41'
   labels:
     app: rhtpa-db
   name: rhtpa-db

--- a/charts/rhtpa-operator/templates/s3-credentials-secret.yaml
+++ b/charts/rhtpa-operator/templates/s3-credentials-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   name: rhtpa-s3-config
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "8"  # After OBC is created
+    argocd.argoproj.io/sync-wave: "39"  # After OBC is created
 data:
   # The OBC creates a secret with these keys automatically
   # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, BUCKET_HOST, BUCKET_NAME, BUCKET_PORT

--- a/charts/rhtpa-operator/templates/spiffe-helper-config.yaml
+++ b/charts/rhtpa-operator/templates/spiffe-helper-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: spiffe-helper-config
   namespace: {{ .Values.rhtpa.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "18"
+    argocd.argoproj.io/sync-wave: "49"
 data:
   config.hcl: |
     agent_address = "/spiffe-workload-api/spire-agent.sock"

--- a/charts/rhtpa-operator/templates/trusted-profile-analyzer.yaml
+++ b/charts/rhtpa-operator/templates/trusted-profile-analyzer.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "rhtpa-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "50"  # Increased delay to ensure operator is fully ready
+    argocd.argoproj.io/sync-wave: "81"  # Increased delay to ensure operator is fully ready
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: CM Configuration Management
@@ -126,7 +126,7 @@ metadata:
   labels:
     {{- include "rhtpa-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-wave: "51"
 placementRef:
   name: placement-policy-rhtpa-trustedprofileanalyzer
   kind: PlacementRule
@@ -144,7 +144,7 @@ metadata:
   labels:
     {{- include "rhtpa-operator.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-wave: "51"
 spec:
   clusterConditions:
     - status: "True"

--- a/charts/supply-chain/templates/workspaces.yaml
+++ b/charts/supply-chain/templates/workspaces.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .name }}
   namespace: {{ .namespace | default $.Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: '20'
+    argocd.argoproj.io/sync-wave: '51'
   labels:
     app.kubernetes.io/component: storage
 spec:

--- a/charts/ztvp-certificates/templates/ca-extraction-cronjob.yaml
+++ b/charts/ztvp-certificates/templates/ca-extraction-cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "ztvp-certificates.fullname" . }}-ca-extractor
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-8"
+    argocd.argoproj.io/sync-wave: "23"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 spec:

--- a/charts/ztvp-certificates/templates/ca-extraction-job-initial.yaml
+++ b/charts/ztvp-certificates/templates/ca-extraction-job-initial.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "ztvp-certificates.fullname" . }}-ca-extractor-initial
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-8"
+    argocd.argoproj.io/sync-wave: "23"
     # Run as regular sync resource (after RBAC at -9, before Policy at -5)
     # Using Prune=false prevents OutOfSync after TTL deletes the completed Job
     argocd.argoproj.io/sync-options: Prune=false

--- a/charts/ztvp-certificates/templates/configmap-script.yaml
+++ b/charts/ztvp-certificates/templates/configmap-script.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "ztvp-certificates.fullname" . }}-script
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
     app.kubernetes.io/component: extraction-script

--- a/charts/ztvp-certificates/templates/distribution-policy.yaml
+++ b/charts/ztvp-certificates/templates/distribution-policy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ztvp-certificates-distribution
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/sync-wave: "26"
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/categories: PR.DS Data Security
     policy.open-cluster-management.io/controls: PR.DS-2 Data-in-transit
@@ -50,7 +50,7 @@ metadata:
   name: ztvp-certificates-distribution-binding
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/sync-wave: "26"
 bindingOverrides:
   remediationAction: enforce
 placementRef:
@@ -68,7 +68,7 @@ metadata:
   name: ztvp-certificates-distribution-placement
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/sync-wave: "26"
 spec:
   predicates:
     - requiredClusterSelector:

--- a/charts/ztvp-certificates/templates/managedclusterset-binding.yaml
+++ b/charts/ztvp-certificates/templates/managedclusterset-binding.yaml
@@ -7,7 +7,7 @@ metadata:
   name: default
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-6"
+    argocd.argoproj.io/sync-wave: "25"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 spec:

--- a/charts/ztvp-certificates/templates/rbac.yaml
+++ b/charts/ztvp-certificates/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "ztvp-certificates.serviceAccountName" . }}
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 ---
@@ -16,7 +16,7 @@ metadata:
   name: {{ include "ztvp-certificates.serviceAccountName" . }}
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 rules:
@@ -30,7 +30,7 @@ metadata:
   name: {{ include "ztvp-certificates.serviceAccountName" . }}
   namespace: {{ .Values.global.namespace }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 roleRef:
@@ -47,7 +47,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "ztvp-certificates.fullname" . }}-ca-reader
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 rules:
@@ -73,7 +73,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "ztvp-certificates.fullname" . }}-ca-reader
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 roleRef:
@@ -91,7 +91,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "ztvp-certificates.fullname" . }}-rollout
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 rules:
@@ -105,7 +105,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "ztvp-certificates.fullname" . }}-rollout
   annotations:
-    argocd.argoproj.io/sync-wave: "-9"
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "ztvp-certificates.labels" . | nindent 4 }}
 roleRef:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ If we want to save some space, we can add these overrides to the `noobaa-mcg` co
       project: hub
       path: charts/noobaa-mcg
       annotations:
-        argocd.argoproj.io/sync-wave: "5"
+        argocd.argoproj.io/sync-wave: "36"
       overrides:
         - name: noobaa.dbSize
           value: 10Gi

--- a/docs/SYNC-WAVE-INVENTORY.md
+++ b/docs/SYNC-WAVE-INVENTORY.md
@@ -1,0 +1,146 @@
+# Argo CD Sync-Wave Inventory
+
+All `argocd.argoproj.io/sync-wave` assignments in `layered-zero-trust`.
+
+A +31 offset was applied to every value so that all waves are positive (>= 1), preserving the original relative ordering. This accommodates the Validated Patterns operator applying the Argo CD super-role later than before, which caused resources with negative sync waves to fail.
+
+## Application-level waves (`values-hub.yaml`)
+
+These control when each Argo CD Application syncs relative to other Applications.
+
+| Application | Old | Current | Comment | Active? |
+| --- | ---: | ---: | --- | --- |
+| compliance-scanning | -30 | 1 | Earliest app | yes |
+| ztvp-certificates | -10 | 21 | Custom CA distribution | yes |
+| openshift-storage (OperatorGroup) | -5 | 26 | Propagated to OperatorGroup | commented |
+| rhtpa-operator (namespace) | -5 | 26 | Before operator subscription | commented |
+| odf (subscription) | -4 | 27 | After OperatorGroup (26) | commented |
+| rhtpa-operator (subscription) | -4 | 27 | After OperatorGroup (26) | commented |
+| quay-operator (subscription) | -3 | 28 | After ODF operator | commented |
+| rhtas-operator (subscription) | -2 | 29 | After Quay operator | commented |
+| quay-enterprise (namespace) | 1 | 32 | Before NooBaa and Quay components | commented |
+| trusted-artifact-signer (namespace) | 1 | 32 | Auto-created by RHTAS operator | commented |
+| trusted-profile-analyzer (namespace) | 1 | 32 | Before RHTPA components | commented |
+| noobaa-mcg | 5 | 36 | Deploy after core services | commented |
+| acs-central | 10 | 41 | — | yes |
+| quay-registry | 10 | 41 | Deploy after NooBaa | commented |
+| trusted-profile-analyzer | 10 | 41 | Chart resources (OBC, DB, etc.) | commented |
+| acs-secured-cluster | 15 | 46 | — | yes |
+| trusted-artifact-signer | 15 | 46 | Deploy after dependencies | commented |
+
+## Chart-level waves (templates)
+
+These control resource ordering within a single Application's sync.
+
+### compliance-scanning (`charts/compliance-scanning/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| apiserver-encryption.yaml | -10 | 21 |
+| pvc.yaml | -10 | 21 |
+| scan-setting.yaml | -10 | 21 |
+| scan-setting-binding.yaml | -10 | 21 |
+
+### ztvp-certificates (`charts/ztvp-certificates/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| rbac.yaml (7 resources) | -9 | 22 |
+| configmap-script.yaml | -9 | 22 |
+| ca-extraction-job-initial.yaml | -8 | 23 |
+| ca-extraction-cronjob.yaml | -8 | 23 |
+| managedclusterset-binding.yaml | -6 | 25 |
+| distribution-policy.yaml (3 resources) | -5 | 26 |
+
+### rhtpa-operator (`charts/rhtpa-operator/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| ingress-ca-job.yaml (SA, Role, RoleBinding, ConfigMap, Job) | 0 | 31 |
+| operator-rolebinding.yaml (2 bindings) | 1 | 32 |
+| ingress-ca-job.yaml (completion Job) | 2 | 33 |
+| oidc-cli-secret.yaml | 3 | 34 |
+| postgresql-serviceaccount.yaml | 5 | 36 |
+| postgresql-external-secret.yaml | 5 | 36 |
+| object-bucket-claim.yaml | 5 | 36 |
+| s3-credentials-secret.yaml | 8 | 39 |
+| postgresql-statefulset.yaml | 10 | 41 |
+| postgresql-service.yaml | 10 | 41 |
+| spiffe-helper-config.yaml | 18 | 49 |
+| trusted-profile-analyzer.yaml (supporting objects) | 20 | 51 |
+| operator-readiness-check.yaml (SA, Role, Job) | 40 | 71 |
+| trusted-profile-analyzer.yaml (Policy/CR) | 50 | 81 |
+
+### noobaa-mcg (`charts/noobaa-mcg/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| default-backingstore.yaml | 1 | 32 |
+| noobaa-system.yaml | 2 | 33 |
+| bucket-class.yaml | 3 | 34 |
+
+### keycloak (`charts/keycloak/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| keycloak.yaml | 5 | 36 |
+| keycloak-realm-import.yaml | 10 | 41 |
+
+### quay-registry (`charts/quay-registry/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| object-bucket-claim.yaml | 5 | 36 |
+| quay-s3-setup-serviceaccount.yaml (5 resources) | 6 | 37 |
+| quay-config-bundle-secret.yaml | 7 | 38 |
+| quay-s3-credentials-job.yaml | 8 | 39 |
+| quay-registry.yaml | 10 | 41 |
+
+### acs-central (`charts/acs-central/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| rbac/* (SA, Role, ClusterRole, bindings) | 1 | 32 |
+| admin-password-secret.yaml | 5 | 36 |
+| central-htpasswd-external-secret.yaml | 5 | 36 |
+| keycloak-client-secret-external-secret.yaml | 5 | 36 |
+| create-htpasswd-field.yaml (Job) | 6 | 37 |
+| central-cr.yaml | 10 | 41 |
+| create-cluster-init-bundle.yaml (Job) | 12 | 43 |
+| create-auth-provider.yaml (Job) | 13 | 44 |
+| console-link.yaml | 15 | 46 |
+
+### acs-secured-cluster (`charts/acs-secured-cluster/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| secured-cluster-cr.yaml | 15 | 46 |
+
+### rhtas-operator (`charts/rhtas-operator/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| securesign.yaml | 15 | 46 |
+
+### qtodo (`charts/qtodo/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| truststore-secret-external-secret.yaml | 5 | 36 |
+| postgresql-statefulset.yaml | 10 | 41 |
+| postgresql-service.yaml | 10 | 41 |
+| qtodo-truststore-config.yaml | 10 | 41 |
+| app-deployment.yaml | 20 | 51 |
+| app-service.yaml | 20 | 51 |
+
+### supply-chain (`charts/supply-chain/templates/`)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| workspaces.yaml | 20 | 51 |
+
+### docs/DEVELOPMENT.md (example snippet, not deployed)
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| noobaa-mcg example | 5 | 36 |

--- a/docs/SYNC-WAVE-INVENTORY.md
+++ b/docs/SYNC-WAVE-INVENTORY.md
@@ -4,35 +4,114 @@ All `argocd.argoproj.io/sync-wave` assignments in `layered-zero-trust`.
 
 A +31 offset was applied to every value so that all waves are positive (>= 1), preserving the original relative ordering. This accommodates the Validated Patterns operator applying the Argo CD super-role later than before, which caused resources with negative sync waves to fail.
 
+## Unified deployment timeline
+
+Every sync-wave in the repository, in order. **App** = hub-level Argo CD Application creation. **chart** = resource inside a chart (resolved locally within that app's sync). **sub** = operator Subscription.
+
+| Wave | Component | Scope | What |
+| ---: | --- | --- | --- |
+| 1 | compliance-scanning | **App** | Argo CD Application created on hub |
+| 5 | acm | **App** | |
+| 5 | rh-cert-manager | **App** | |
+| 10 | acm-managed-clusters | **App** | |
+| 21 | ztvp-certificates | **App** | |
+| 21 | └ compliance-scanning | chart | apiserver-encryption, pvc, scan-setting, scan-setting-binding |
+| 22 | └ ztvp-certificates | chart | RBAC (7 resources), configmap-script |
+| 23 | └ ztvp-certificates | chart | ca-extraction-job-initial, ca-extraction-cronjob |
+| 25 | vault | **App** | |
+| 25 | └ ztvp-certificates | chart | managedclusterset-binding |
+| 26 | └ ztvp-certificates | chart | distribution-policy (3 resources) |
+| 26 | └ openshift-storage | ns | Namespace + OperatorGroup |
+| 26 | └ rhtpa-operator | ns | Namespace + OperatorGroup |
+| 27 | └ odf | sub | ODF operator install |
+| 27 | └ rhtpa-operator | sub | RHTPA operator install |
+| 28 | └ quay-operator | sub | Quay operator install |
+| 29 | └ rhtas-operator | sub | RHTAS operator install |
+| 30 | golang-external-secrets | **App** | |
+| 30 | zero-trust-workload-identity-manager | **App** | |
+| 31 | └ rhtpa-operator | chart | ingress-ca-job (SA, Role, RoleBinding, ConfigMap, Job) |
+| 32 | └ rhtpa-operator | chart | operator-rolebinding (2 bindings) |
+| 32 | └ noobaa-mcg | chart | default-backingstore |
+| 32 | └ acs-central | chart | rbac/* (SA, Role, ClusterRole, bindings) |
+| 32 | └ quay-enterprise | ns | Namespace |
+| 32 | └ trusted-artifact-signer | ns | Namespace |
+| 32 | └ trusted-profile-analyzer | ns | Namespace |
+| 33 | └ rhtpa-operator | chart | ingress-ca-job (completion Job) |
+| 33 | └ noobaa-mcg | chart | noobaa-system |
+| 34 | └ rhtpa-operator | chart | oidc-cli-secret |
+| 34 | └ noobaa-mcg | chart | bucket-class |
+| 35 | rh-keycloak | **App** | |
+| 36 | noobaa-mcg | **App** | |
+| 36 | └ rhtpa-operator | chart | postgresql-serviceaccount, postgresql-external-secret, object-bucket-claim |
+| 36 | └ keycloak | chart | keycloak.yaml (Keycloak CR) |
+| 36 | └ quay-registry | chart | object-bucket-claim |
+| 36 | └ acs-central | chart | admin-password-secret, central-htpasswd-external-secret, keycloak-client-secret-external-secret |
+| 36 | └ qtodo | chart | truststore-secret-external-secret |
+| 37 | └ quay-registry | chart | quay-s3-setup-serviceaccount (5 resources) |
+| 37 | └ acs-central | chart | create-htpasswd-field (Job) |
+| 38 | qtodo | **App** | |
+| 38 | └ quay-registry | chart | quay-config-bundle-secret |
+| 39 | └ rhtpa-operator | chart | s3-credentials-secret |
+| 39 | └ quay-registry | chart | quay-s3-credentials-job |
+| 41 | acs-central | **App** | |
+| 41 | quay-registry | **App** | |
+| 41 | trusted-profile-analyzer | **App** | |
+| 41 | └ rhtpa-operator | chart | postgresql-statefulset, postgresql-service |
+| 41 | └ keycloak | chart | keycloak-realm-import |
+| 41 | └ quay-registry | chart | quay-registry (QuayRegistry CR) |
+| 41 | └ acs-central | chart | central-cr (Central CR) |
+| 41 | └ qtodo | chart | postgresql-statefulset, postgresql-service, qtodo-truststore-config |
+| 43 | └ acs-central | chart | create-cluster-init-bundle (Job) |
+| 44 | └ acs-central | chart | create-auth-provider (Job) |
+| 46 | acs-secured-cluster | **App** | |
+| 46 | trusted-artifact-signer | **App** | |
+| 46 | └ acs-central | chart | console-link |
+| 46 | └ acs-secured-cluster | chart | secured-cluster-cr |
+| 46 | └ rhtas-operator | chart | securesign |
+| 48 | supply-chain | **App** | |
+| 49 | └ rhtpa-operator | chart | spiffe-helper-config |
+| 51 | └ rhtpa-operator | chart | trusted-profile-analyzer (supporting objects) |
+| 51 | └ qtodo | chart | app-deployment, app-service |
+| 51 | └ supply-chain | chart | workspaces |
+| 71 | └ rhtpa-operator | chart | operator-readiness-check (SA, Role, Job) |
+| 81 | └ rhtpa-operator | chart | trusted-profile-analyzer (Policy/CR) |
+
 ## Application-level waves (`values-hub.yaml`)
 
-These control when each Argo CD Application syncs relative to other Applications.
-
-| Application | Old | Current | Comment | Active? |
-| --- | ---: | ---: | --- | --- |
-| compliance-scanning | -30 | 1 | Earliest app | yes |
-| ztvp-certificates | -10 | 21 | Custom CA distribution | yes |
-| openshift-storage (OperatorGroup) | -5 | 26 | Propagated to OperatorGroup | commented |
-| rhtpa-operator (namespace) | -5 | 26 | Before operator subscription | commented |
-| odf (subscription) | -4 | 27 | After OperatorGroup (26) | commented |
-| rhtpa-operator (subscription) | -4 | 27 | After OperatorGroup (26) | commented |
-| quay-operator (subscription) | -3 | 28 | After ODF operator | commented |
-| rhtas-operator (subscription) | -2 | 29 | After Quay operator | commented |
-| quay-enterprise (namespace) | 1 | 32 | Before NooBaa and Quay components | commented |
-| trusted-artifact-signer (namespace) | 1 | 32 | Auto-created by RHTAS operator | commented |
-| trusted-profile-analyzer (namespace) | 1 | 32 | Before RHTPA components | commented |
-| noobaa-mcg | 5 | 36 | Deploy after core services | commented |
-| acs-central | 10 | 41 | — | yes |
-| quay-registry | 10 | 41 | Deploy after NooBaa | commented |
-| trusted-profile-analyzer | 10 | 41 | Chart resources (OBC, DB, etc.) | commented |
-| acs-secured-cluster | 15 | 46 | — | yes |
-| trusted-artifact-signer | 15 | 46 | Deploy after dependencies | commented |
+| Application | Old | Current | Comment |
+| --- | ---: | ---: | --- |
+| compliance-scanning | -30 | 1 | Earliest app |
+| rh-cert-manager | — | 5 | Infrastructure, early (newly added) |
+| acm | — | 5 | Infrastructure, early (newly added) |
+| acm-managed-clusters | — | 10 | After ACM (newly added) |
+| ztvp-certificates | -10 | 21 | Custom CA distribution |
+| vault | — | 25 | Core secret store (newly added) |
+| openshift-storage (OperatorGroup) | -5 | 26 | Propagated to OperatorGroup |
+| rhtpa-operator (namespace) | -5 | 26 | Before operator subscription |
+| odf (subscription) | -4 | 27 | After OperatorGroup (26) |
+| rhtpa-operator (subscription) | -4 | 27 | After OperatorGroup (26) |
+| quay-operator (subscription) | -3 | 28 | After ODF operator |
+| rhtas-operator (subscription) | -2 | 29 | After Quay operator |
+| golang-external-secrets | — | 30 | After Vault (newly added) |
+| zero-trust-workload-identity-manager | — | 30 | After Vault/certs (newly added) |
+| quay-enterprise (namespace) | 1 | 32 | Before NooBaa and Quay components |
+| trusted-artifact-signer (namespace) | 1 | 32 | Auto-created by RHTAS operator |
+| trusted-profile-analyzer (namespace) | 1 | 32 | Before RHTPA components |
+| rh-keycloak | — | 35 | After ZTWIM for SPIFFE IdP (newly added) |
+| noobaa-mcg | 5 | 36 | Deploy after core services |
+| qtodo | — | 38 | After Keycloak, Vault (newly added) |
+| acs-central | 10 | 41 | — |
+| quay-registry | 10 | 41 | Deploy after NooBaa |
+| trusted-profile-analyzer | 10 | 41 | Chart resources (OBC, DB, etc.) |
+| acs-secured-cluster | 15 | 46 | — |
+| trusted-artifact-signer | 15 | 46 | Deploy after dependencies |
+| supply-chain | — | 48 | After RHTAS/ACS, before chart templates (newly added) |
 
 ## Chart-level waves (templates)
 
-These control resource ordering within a single Application's sync.
+These control resource ordering within a single Application's sync. Template waves are resolved locally within each app, not globally across all apps.
 
-### compliance-scanning (`charts/compliance-scanning/templates/`)
+### compliance-scanning (`charts/compliance-scanning/templates/`) — App wave: 1
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
@@ -41,7 +120,7 @@ These control resource ordering within a single Application's sync.
 | scan-setting.yaml | -10 | 21 |
 | scan-setting-binding.yaml | -10 | 21 |
 
-### ztvp-certificates (`charts/ztvp-certificates/templates/`)
+### ztvp-certificates (`charts/ztvp-certificates/templates/`) — App wave: 21
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
@@ -52,7 +131,58 @@ These control resource ordering within a single Application's sync.
 | managedclusterset-binding.yaml | -6 | 25 |
 | distribution-policy.yaml (3 resources) | -5 | 26 |
 
-### rhtpa-operator (`charts/rhtpa-operator/templates/`)
+### noobaa-mcg (`charts/noobaa-mcg/templates/`) — App wave: 36
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| default-backingstore.yaml | 1 | 32 |
+| noobaa-system.yaml | 2 | 33 |
+| bucket-class.yaml | 3 | 34 |
+
+### keycloak (`charts/keycloak/templates/`) — App wave: 35
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| keycloak.yaml | 5 | 36 |
+| keycloak-realm-import.yaml | 10 | 41 |
+
+### quay-registry (`charts/quay-registry/templates/`) — App wave: 41
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| object-bucket-claim.yaml | 5 | 36 |
+| quay-s3-setup-serviceaccount.yaml (5 resources) | 6 | 37 |
+| quay-config-bundle-secret.yaml | 7 | 38 |
+| quay-s3-credentials-job.yaml | 8 | 39 |
+| quay-registry.yaml | 10 | 41 |
+
+### acs-central (`charts/acs-central/templates/`) — App wave: 41
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| rbac/* (SA, Role, ClusterRole, bindings) | 1 | 32 |
+| admin-password-secret.yaml | 5 | 36 |
+| central-htpasswd-external-secret.yaml | 5 | 36 |
+| keycloak-client-secret-external-secret.yaml | 5 | 36 |
+| create-htpasswd-field.yaml (Job) | 6 | 37 |
+| central-cr.yaml | 10 | 41 |
+| create-cluster-init-bundle.yaml (Job) | 12 | 43 |
+| create-auth-provider.yaml (Job) | 13 | 44 |
+| console-link.yaml | 15 | 46 |
+
+### acs-secured-cluster (`charts/acs-secured-cluster/templates/`) — App wave: 46
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| secured-cluster-cr.yaml | 15 | 46 |
+
+### rhtas-operator (`charts/rhtas-operator/templates/`) — App wave: 46
+
+| Resource | Old | Current |
+| --- | ---: | ---: |
+| securesign.yaml | 15 | 46 |
+
+### rhtpa-operator (`charts/rhtpa-operator/templates/`) — App wave: 41
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
@@ -71,58 +201,7 @@ These control resource ordering within a single Application's sync.
 | operator-readiness-check.yaml (SA, Role, Job) | 40 | 71 |
 | trusted-profile-analyzer.yaml (Policy/CR) | 50 | 81 |
 
-### noobaa-mcg (`charts/noobaa-mcg/templates/`)
-
-| Resource | Old | Current |
-| --- | ---: | ---: |
-| default-backingstore.yaml | 1 | 32 |
-| noobaa-system.yaml | 2 | 33 |
-| bucket-class.yaml | 3 | 34 |
-
-### keycloak (`charts/keycloak/templates/`)
-
-| Resource | Old | Current |
-| --- | ---: | ---: |
-| keycloak.yaml | 5 | 36 |
-| keycloak-realm-import.yaml | 10 | 41 |
-
-### quay-registry (`charts/quay-registry/templates/`)
-
-| Resource | Old | Current |
-| --- | ---: | ---: |
-| object-bucket-claim.yaml | 5 | 36 |
-| quay-s3-setup-serviceaccount.yaml (5 resources) | 6 | 37 |
-| quay-config-bundle-secret.yaml | 7 | 38 |
-| quay-s3-credentials-job.yaml | 8 | 39 |
-| quay-registry.yaml | 10 | 41 |
-
-### acs-central (`charts/acs-central/templates/`)
-
-| Resource | Old | Current |
-| --- | ---: | ---: |
-| rbac/* (SA, Role, ClusterRole, bindings) | 1 | 32 |
-| admin-password-secret.yaml | 5 | 36 |
-| central-htpasswd-external-secret.yaml | 5 | 36 |
-| keycloak-client-secret-external-secret.yaml | 5 | 36 |
-| create-htpasswd-field.yaml (Job) | 6 | 37 |
-| central-cr.yaml | 10 | 41 |
-| create-cluster-init-bundle.yaml (Job) | 12 | 43 |
-| create-auth-provider.yaml (Job) | 13 | 44 |
-| console-link.yaml | 15 | 46 |
-
-### acs-secured-cluster (`charts/acs-secured-cluster/templates/`)
-
-| Resource | Old | Current |
-| --- | ---: | ---: |
-| secured-cluster-cr.yaml | 15 | 46 |
-
-### rhtas-operator (`charts/rhtas-operator/templates/`)
-
-| Resource | Old | Current |
-| --- | ---: | ---: |
-| securesign.yaml | 15 | 46 |
-
-### qtodo (`charts/qtodo/templates/`)
+### qtodo (`charts/qtodo/templates/`) — App wave: 38
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
@@ -133,7 +212,7 @@ These control resource ordering within a single Application's sync.
 | app-deployment.yaml | 20 | 51 |
 | app-service.yaml | 20 | 51 |
 
-### supply-chain (`charts/supply-chain/templates/`)
+### supply-chain (`charts/supply-chain/templates/`) — App wave: 48
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
@@ -144,3 +223,10 @@ These control resource ordering within a single Application's sync.
 | Resource | Old | Current |
 | --- | ---: | ---: |
 | noobaa-mcg example | 5 | 36 |
+
+## Notes
+
+- **"Old"** = value before the +31 offset. **"—"** = no sync-wave existed (defaulted to 0).
+- **"Current"** = value after the +31 offset plus newly added application-level annotations.
+- Template waves are resolved **locally within each app sync**, not globally. A template wave of 32 inside acs-central (app wave 41) does not conflict with a template wave of 32 inside noobaa-mcg (app wave 36); they run independently.
+- Sync waves control **Application creation order**, not readiness. A later wave means the Application resource is submitted to the hub later, but the earlier app's pods may not be fully running yet. For hard readiness gates, use Argo CD health checks or resource hooks.

--- a/docs/SYNC-WAVE-INVENTORY.md
+++ b/docs/SYNC-WAVE-INVENTORY.md
@@ -70,6 +70,7 @@ Every sync-wave in the repository, in order. **App** = hub-level Argo CD Applica
 | 46 | └ rhtas-operator | chart | securesign |
 | 48 | supply-chain | **App** | |
 | 49 | └ rhtpa-operator | chart | spiffe-helper-config |
+| 51 | acs-policies | **App** | After ACS Central + Secured Cluster |
 | 51 | └ rhtpa-operator | chart | trusted-profile-analyzer (supporting objects) |
 | 51 | └ qtodo | chart | app-deployment, app-service |
 | 51 | └ supply-chain | chart | workspaces |
@@ -106,12 +107,32 @@ Every sync-wave in the repository, in order. **App** = hub-level Argo CD Applica
 | acs-secured-cluster | 15 | 46 | — |
 | trusted-artifact-signer | 15 | 46 | Deploy after dependencies |
 | supply-chain | — | 48 | After RHTAS/ACS, before chart templates (newly added) |
+| acs-policies | 20 | 51 | After ACS Central + Secured Cluster |
+
+## Application-level waves (`values-coco-dev.yaml`)
+
+The CoCo development configuration reuses several of the same components. Only the active `compliance-scanning` wave differs from the commented-out defaults; other entries are commented out but updated for consistency.
+
+| Application | Old | Current | Comment |
+| --- | ---: | ---: | --- |
+| compliance-scanning | -30 | 1 | Earliest app |
+| openshift-storage (OperatorGroup) | -5 | 26 | Commented; propagated to OperatorGroup |
+| quay-enterprise (namespace) | 1 | 32 | Commented; before NooBaa and Quay components |
+| trusted-artifact-signer (namespace) | 1 | 32 | Commented; auto-created by RHTAS operator |
+| odf (subscription) | -4 | 27 | Commented; after OperatorGroup (26) |
+| quay-operator (subscription) | -3 | 28 | Commented; after ODF operator |
+| rhtas-operator (subscription) | -2 | 29 | Commented; after Quay operator |
+| noobaa-mcg | 5 | 36 | Commented; deploy after core services |
+| quay-registry | 10 | 41 | Commented; deploy after NooBaa |
+| trusted-artifact-signer | 15 | 46 | Commented; deploy after dependencies |
 
 ## Chart-level waves (templates)
 
 These control resource ordering within a single Application's sync. Template waves are resolved locally within each app, not globally across all apps.
 
-### compliance-scanning (`charts/compliance-scanning/templates/`) — App wave: 1
+Charts marked **(external)** have been externalized to standalone repositories managed under [validatedpatterns](https://github.com/validatedpatterns). Their resource-level sync-wave annotations are maintained in those repos, not here. The tables below reflect the +31 offset values that each external chart should carry.
+
+### compliance-scanning — **(external)** `ocp-compliance-scanning-chart` v0.0.3 — App wave: 1
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
@@ -139,14 +160,14 @@ These control resource ordering within a single Application's sync. Template wav
 | noobaa-system.yaml | 2 | 33 |
 | bucket-class.yaml | 3 | 34 |
 
-### keycloak (`charts/keycloak/templates/`) — App wave: 35
+### keycloak — **(external)** `rhbk-chart` v0.0.4 — App wave: 35
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
 | keycloak.yaml | 5 | 36 |
 | keycloak-realm-import.yaml | 10 | 41 |
 
-### quay-registry (`charts/quay-registry/templates/`) — App wave: 41
+### quay-registry — **(external)** `quay-chart` v0.1.3 — App wave: 41
 
 | Resource | Old | Current |
 | --- | ---: | ---: |
@@ -226,7 +247,8 @@ These control resource ordering within a single Application's sync. Template wav
 
 ## Notes
 
-- **"Old"** = value before the +31 offset. **"—"** = no sync-wave existed (defaulted to 0).
+- **"Old"** = value before the +31 offset. **"---"** = no sync-wave existed (defaulted to 0).
 - **"Current"** = value after the +31 offset plus newly added application-level annotations.
 - Template waves are resolved **locally within each app sync**, not globally. A template wave of 32 inside acs-central (app wave 41) does not conflict with a template wave of 32 inside noobaa-mcg (app wave 36); they run independently.
 - Sync waves control **Application creation order**, not readiness. A later wave means the Application resource is submitted to the hub later, but the earlier app's pods may not be fully running yet. For hard readiness gates, use Argo CD health checks or resource hooks.
+- **Externalized charts**: Five charts (certmanager, compliance-scanning, keycloak/RHBK, quay-registry, ZTWIM) are maintained in standalone repositories. Their resource-level sync-wave annotations are managed there and pinned via `chartVersion` in `values-hub.yaml`. Application-level sync-waves remain in this repository.

--- a/values-coco-dev.yaml
+++ b/values-coco-dev.yaml
@@ -56,17 +56,17 @@ clusterGroup:
     #     targetNamespace: openshift-storage
     #     annotations:
     #       openshift.io/cluster-monitoring: "true"
-    #       argocd.argoproj.io/sync-wave: "-5"  # Propagated to OperatorGroup by framework
+    #       argocd.argoproj.io/sync-wave: "26"  # Propagated to OperatorGroup by framework
     # - quay-enterprise:
     #     annotations:
-    #       argocd.argoproj.io/sync-wave: "1"  # Create before NooBaa and all Quay components
+    #       argocd.argoproj.io/sync-wave: "32"  # Create before NooBaa and all Quay components
     #     labels:
     #       openshift.io/cluster-monitoring: "true"
     # RHTAS namespace (required when RHTAS application is enabled)
     # COMMENTED OUT: Uncomment to enable RHTAS with SPIFFE signing
     # - trusted-artifact-signer:
     #     annotations:
-    #       argocd.argoproj.io/sync-wave: "1"  # Auto-created by RHTAS operator
+    #       argocd.argoproj.io/sync-wave: "32"  # Auto-created by RHTAS operator
     #     labels:
     #       openshift.io/cluster-monitoring: "true"
     - zero-trust-workload-identity-manager:
@@ -152,13 +152,13 @@ clusterGroup:
     #   namespace: openshift-storage
     #   channel: stable-4.19
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "-4"  # Install after OperatorGroup (-5)
+    #     argocd.argoproj.io/sync-wave: "27"  # Install after OperatorGroup (26)
     # quay-operator:
     #   name: quay-operator
     #   namespace: openshift-operators
     #   channel: stable-3.15
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "-3"  # Install after ODF operator
+    #     argocd.argoproj.io/sync-wave: "28"  # Install after ODF operator
     # RHTAS operator subscription (required when RHTAS application is enabled)
     # COMMENTED OUT: Uncomment to enable RHTAS with SPIFFE integration
     # rhtas-operator:
@@ -166,7 +166,7 @@ clusterGroup:
     #   namespace: openshift-operators
     #   channel: stable
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "-2"  # Install after Quay operator, before applications
+    #     argocd.argoproj.io/sync-wave: "29"  # Install after Quay operator, before applications
     #   catalogSource: redhat-operators
   projects:
     - hub
@@ -220,7 +220,7 @@ clusterGroup:
       name: compliance-scanning
       namespace: openshift-compliance
       annotations:
-        argocd.argoproj.io/sync-wave: '-30'
+        argocd.argoproj.io/sync-wave: '1'
       project: hub
       path: charts/compliance-scanning
     vault:
@@ -251,7 +251,7 @@ clusterGroup:
     #   project: hub
     #   path: charts/noobaa-mcg
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "5"  # Deploy after core services
+    #     argocd.argoproj.io/sync-wave: "36"  # Deploy after core services
     # Quay Container Registry (uses NooBaa for storage)
     # quay-registry:
     #   name: quay-registry
@@ -259,7 +259,7 @@ clusterGroup:
     #   project: hub  
     #   path: charts/quay-registry
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "10"  # Deploy after NooBaa storage backend
+    #     argocd.argoproj.io/sync-wave: "41"  # Deploy after NooBaa storage backend
     # RHTAS with SPIFFE Integration
     # COMMENTED OUT: Uncomment to enable RHTAS with SPIFFE and Email issuers
     # Depends on: Vault, SPIRE, Keycloak (for Email OIDC issuer if used)
@@ -269,7 +269,7 @@ clusterGroup:
     #   project: hub
     #   path: charts/rhtas-operator
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "15"  # Deploy after dependencies
+    #     argocd.argoproj.io/sync-wave: "46"  # Deploy after dependencies
     #   overrides:
     #     # OIDC Issuer Configuration - Both can be enabled simultaneously
     #     # Enable SPIFFE issuer for workload identity

--- a/values-coco-dev.yaml
+++ b/values-coco-dev.yaml
@@ -222,7 +222,8 @@ clusterGroup:
       annotations:
         argocd.argoproj.io/sync-wave: '1'
       project: hub
-      path: charts/compliance-scanning
+      chart: ocp-compliance-scanning
+      chartVersion: 0.0.*
     vault:
       name: vault
       namespace: vault
@@ -256,8 +257,9 @@ clusterGroup:
     # quay-registry:
     #   name: quay-registry
     #   namespace: quay-enterprise
-    #   project: hub  
-    #   path: charts/quay-registry
+    #   project: hub
+    #   chart: quay
+    #   chartVersion: 0.1.*
     #   annotations:
     #     argocd.argoproj.io/sync-wave: "41"  # Deploy after NooBaa storage backend
     # RHTAS with SPIFFE Integration
@@ -295,17 +297,20 @@ clusterGroup:
     #   name: rh-keycloak
     #   namespace: keycloak-system
     #   project: hub
-    #   path: charts/keycloak
+    #   chart: rhbk
+    #   chartVersion: 0.0.*
     rh-cert-manager:
       name: rh-cert-manager
       namespace: cert-manager-operator
       project: hub
-      path: charts/certmanager
+      chart: ocp-certmanager
+      chartVersion: 0.2.*
     zero-trust-workload-identity-manager:
       name: zero-trust-workload-identity-manager
       namespace: zero-trust-workload-identity-manager
       project: hub
-      path: charts/zero-trust-workload-identity-manager
+      chart: ztwim
+      chartVersion: 0.1.*
       overrides:
         - name: spire.clusterName
           value: hub

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -9,5 +9,4 @@ main:
   clusterGroupName: hub
   multiSourceConfig:
     enabled: true
-    # Pinned version to avoid issues introduced by https://github.com/validatedpatterns/clustergroup-chart/pull/103
-    clusterGroupChartVersion: "0.9.45"
+    clusterGroupChartVersion: "0.9.*"

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -33,27 +33,27 @@ clusterGroup:
     #     targetNamespace: openshift-storage
     #     annotations:
     #       openshift.io/cluster-monitoring: "true"
-    #       argocd.argoproj.io/sync-wave: "-5"  # Propagated to OperatorGroup by framework
+    #       argocd.argoproj.io/sync-wave: "26"  # Propagated to OperatorGroup by framework
     # - quay-enterprise:
     #     annotations:
-    #       argocd.argoproj.io/sync-wave: "1"  # Create before NooBaa and all Quay components
+    #       argocd.argoproj.io/sync-wave: "32"  # Create before NooBaa and all Quay components
     #     labels:
     #       openshift.io/cluster-monitoring: "true"
     # RHTAS namespace (required when RHTAS application is enabled)
     # COMMENTED OUT: Uncomment to enable RHTAS with SPIFFE signing
     # - trusted-artifact-signer:
     #     annotations:
-    #       argocd.argoproj.io/sync-wave: "1"  # Auto-created by RHTAS operator
+    #       argocd.argoproj.io/sync-wave: "32"  # Auto-created by RHTAS operator
     #     labels:
     #       openshift.io/cluster-monitoring: "true"
     # - rhtpa-operator:
     #     operatorGroup: true
     #     targetNamespace: rhtpa-operator
     #     annotations:
-    #       argocd.argoproj.io/sync-wave: "-5"  # Create before operator subscription
+    #       argocd.argoproj.io/sync-wave: "26"  # Create before operator subscription
     # - trusted-profile-analyzer:
     #     annotations:
-    #       argocd.argoproj.io/sync-wave: "1"  # Create before RHTPA components
+    #       argocd.argoproj.io/sync-wave: "32"  # Create before RHTPA components
     #     labels:
     #       openshift.io/cluster-monitoring: "true"
     - zero-trust-workload-identity-manager:
@@ -121,13 +121,13 @@ clusterGroup:
     #   namespace: openshift-storage
     #   channel: stable-4.20
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "-4"  # Install after OperatorGroup (-5)
+    #     argocd.argoproj.io/sync-wave: "27"  # Install after OperatorGroup (26)
     # quay-operator:
     #   name: quay-operator
     #   namespace: openshift-operators
     #   channel: stable-3.15
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "-3"  # Install after ODF operator
+    #     argocd.argoproj.io/sync-wave: "28"  # Install after ODF operator
     # RHTAS operator subscription (required when RHTAS application is enabled)
     # COMMENTED OUT: Uncomment to enable RHTAS with SPIFFE integration
     # rhtas-operator:
@@ -135,7 +135,7 @@ clusterGroup:
     #   namespace: openshift-operators
     #   channel: stable
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "-2"  # Install after Quay operator, before applications
+    #     argocd.argoproj.io/sync-wave: "29"  # Install after Quay operator, before applications
     #   catalogSource: redhat-operators
     # RHTPA operator subscription
     # Channel: stable-v1.1 provides latest 1.1.x patch updates
@@ -146,7 +146,7 @@ clusterGroup:
     #   channel: stable-v1.1  # Use stable-v1.1 channel for 1.1.x updates
     #   catalogSource: redhat-operators
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "-4"  # Install after OperatorGroup (-5), before applications
+    #     argocd.argoproj.io/sync-wave: "27"  # Install after OperatorGroup (26), before applications
   projects:
     - hub
   # Explicitly mention the cluster-state based overrides we plan to use for this pattern.
@@ -176,7 +176,7 @@ clusterGroup:
       project: hub
       path: charts/ztvp-certificates
       annotations:
-        argocd.argoproj.io/sync-wave: "-10"
+        argocd.argoproj.io/sync-wave: "21"
       # Ignore the ACM-replicated policy in local-cluster namespace
       # ACM automatically creates policy replicas with name pattern: <source-ns>.<policy-name>
       ignoreDifferences:
@@ -255,7 +255,7 @@ clusterGroup:
       name: compliance-scanning
       namespace: openshift-compliance
       annotations:
-        argocd.argoproj.io/sync-wave: '-30'
+        argocd.argoproj.io/sync-wave: '1'
       project: hub
       chart: ocp-compliance-scanning
       chartVersion: 0.0.*
@@ -337,7 +337,7 @@ clusterGroup:
     #   project: hub
     #   path: charts/noobaa-mcg
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "5"  # Deploy after core services
+    #     argocd.argoproj.io/sync-wave: "36"  # Deploy after core services
     # Quay Container Registry (uses NooBaa for storage)
     # quay-registry:
     #   name: quay-registry
@@ -346,7 +346,7 @@ clusterGroup:
     #   chart: quay
     #   chartVersion: 0.1.*
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "10"  # Deploy after NooBaa storage backend
+    #     argocd.argoproj.io/sync-wave: "41"  # Deploy after NooBaa storage backend
     # RHTAS with SPIFFE Integration
     # COMMENTED OUT: Uncomment to enable RHTAS with SPIFFE and Email issuers
     # Depends on: Vault, SPIRE, Keycloak (for Email OIDC issuer if used)
@@ -356,7 +356,7 @@ clusterGroup:
     #   project: hub
     #   path: charts/rhtas-operator
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "15"  # Deploy after dependencies
+    #     argocd.argoproj.io/sync-wave: "46"  # Deploy after dependencies
     #   overrides:
     #     # OIDC Issuer Configuration - Both can be enabled simultaneously
     #     # Enable SPIFFE issuer for workload identity
@@ -379,8 +379,8 @@ clusterGroup:
     #   project: hub
     #   path: charts/rhtpa-operator
     #   annotations:
-    #     argocd.argoproj.io/sync-wave: "10"  # Create chart resources (OBC, DB, etc.)
-    #     # Note: The TrustedProfileAnalyzer CR is created by ACM Policy at wave 50
+    #     argocd.argoproj.io/sync-wave: "41"  # Create chart resources (OBC, DB, etc.)
+    #     # Note: The TrustedProfileAnalyzer CR is created by ACM Policy at wave 81
     #     # to ensure the operator is fully ready (mitigates v1.1.0 initialization bug)
     #   # Ignore differences to prevent OutOfSync status
     #   ignoreDifferences:
@@ -541,7 +541,7 @@ clusterGroup:
           jsonPointers:
             - /spec/scanner/scannerComponent
       annotations:
-        argocd.argoproj.io/sync-wave: "10"
+        argocd.argoproj.io/sync-wave: "41"
 
     # ACS Secured Cluster
     acs-secured-cluster:
@@ -556,7 +556,7 @@ clusterGroup:
         - /values-global.yaml
         - /values-{{ .Values.global.pattern }}-hub.yaml
       annotations:
-        argocd.argoproj.io/sync-wave: "15"
+        argocd.argoproj.io/sync-wave: "46"
     # ACS Policies
     acs-policies:
       name: acs-policies
@@ -564,7 +564,7 @@ clusterGroup:
       project: hub
       path: charts/acs-policies
       annotations:
-        argocd.argoproj.io/sync-wave: "20"
+        argocd.argoproj.io/sync-wave: "51"
   argoCD:
     resourceHealthChecks:
       - check: |

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -232,6 +232,8 @@ clusterGroup:
       project: hub
       chart: acm
       chartVersion: 0.1.*
+      annotations:
+        argocd.argoproj.io/sync-wave: "5"
       ignoreDifferences:
         - group: internal.open-cluster-management.io
           kind: ManagedClusterInfo
@@ -245,6 +247,8 @@ clusterGroup:
       name: acm-managed-clusters
       project: hub
       path: charts/acm-managed-clusters
+      annotations:
+        argocd.argoproj.io/sync-wave: "10"
       ignoreDifferences:
         - group: cluster.open-cluster-management.io
           kind: ManagedCluster
@@ -271,6 +275,8 @@ clusterGroup:
       project: hub
       chart: hashicorp-vault
       chartVersion: 0.1.*
+      annotations:
+        argocd.argoproj.io/sync-wave: "25"
       # Custom Vault policies for least-privilege access
       # Each application gets access only to its specific secrets path
       #
@@ -427,12 +433,16 @@ clusterGroup:
       project: hub
       chart: golang-external-secrets
       chartVersion: 0.1.*
+      annotations:
+        argocd.argoproj.io/sync-wave: "30"
     rh-keycloak:
       name: rh-keycloak
       namespace: keycloak-system
       project: hub
       chart: rhbk
       chartVersion: 0.0.*
+      annotations:
+        argocd.argoproj.io/sync-wave: "35"
       # SPIFFE Identity Provider is enabled by default in the chart.
       # Override issuer/jwksUrl only if auto-generated values from cluster domain are not suitable.
       # overrides:
@@ -446,12 +456,16 @@ clusterGroup:
       project: hub
       chart: ocp-certmanager
       chartVersion: 0.2.*
+      annotations:
+        argocd.argoproj.io/sync-wave: "5"
     zero-trust-workload-identity-manager:
       name: zero-trust-workload-identity-manager
       namespace: zero-trust-workload-identity-manager
       project: hub
       chart: ztwim
       chartVersion: 0.1.*
+      annotations:
+        argocd.argoproj.io/sync-wave: "30"
       overrides:
         - name: spire.clusterName
           value: hub
@@ -460,6 +474,8 @@ clusterGroup:
       namespace: qtodo
       project: hub
       path: charts/qtodo
+      annotations:
+        argocd.argoproj.io/sync-wave: "38"
       ignoreDifferences:
         - kind: ServiceAccount
           jqPathExpressions:
@@ -492,6 +508,8 @@ clusterGroup:
     #  name: supply-chain
     #  project: hub
     #  path: charts/supply-chain
+    #  annotations:
+    #    argocd.argoproj.io/sync-wave: "48"
     #  ignoreDifferences:
     #    - kind: ServiceAccount
     #      jqPathExpressions:


### PR DESCRIPTION
The Validated Patterns operator now applies the Argo CD super-role (ClusterRole) later in the deployment lifecycle. Resources annotated with negative sync-wave values could attempt to sync before the role existed, causing failures.

This adds +31 to every argocd.argoproj.io/sync-wave annotation across all charts, values-hub.yaml, and docs. Relative ordering is preserved; the smallest wave is now 1 (was -30). Inline comments referencing old wave numbers are updated to match.

See docs/SYNC-WAVE-INVENTORY.md for a full old/current mapping table.