### PR TITLE
Remove MCP wait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ install: operator-deploy post-install ## installs the pattern and loads the secr
 .PHONY: post-install
 post-install: ## Post-install tasks
 	make load-secrets
-	@echo "Waiting for MachineConfigPool rollout to complete..."
-	oc wait mcp/master --for=condition=Updated --timeout=600s
 	make vault-config-jwt
 	@echo "Done"
 


### PR DESCRIPTION
Reverting a change that waits for master MCP's. Some target environments do not have MCP's available (for example Managed HCP environments)