### PR TITLE
Add configurable rhtas.redhat.com/log-type annotation for RHTAS

### DIFF
--- a/charts/rhtas-operator/templates/_helpers.tpl
+++ b/charts/rhtas-operator/templates/_helpers.tpl
@@ -51,3 +51,12 @@ app.kubernetes.io/name: {{ include "rhtas-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{/*
+Validate logType variables
+*/}}
+{{- define "log-type.validations" }}
+{{- $logTypes := list "dev" "prod" }}
+{{- if not (has .Values.rhtas.logType $logTypes) }}
+{{- fail "Wrong value set in .Values.rhtas.logType" }}
+{{- end }}
+{{- end }}

--- a/charts/rhtas-operator/templates/securesign.yaml
+++ b/charts/rhtas-operator/templates/securesign.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- if .Values.rhtas.monitoring.enabled }}
     rhtas.redhat.com/metrics: "true"
     {{- end }}
+    {{- if ne .Values.rhtas.logType "prod" }}
+    rhtas.redhat.com/log-type: {{ .Values.rhtas.logType }}
+    {{- end }}
 spec:
   # Fulcio - Certificate Authority
   fulcio:

--- a/charts/rhtas-operator/templates/securesign.yaml
+++ b/charts/rhtas-operator/templates/securesign.yaml
@@ -13,7 +13,8 @@ metadata:
     rhtas.redhat.com/metrics: "true"
     {{- end }}
     {{- if ne .Values.rhtas.logType "prod" }}
-    rhtas.redhat.com/log-type: {{ .Values.rhtas.logType }}
+    {{- include "log-type.validations" . }}
+    rhtas.redhat.com/log-type: {{ .Values.rhtas.logType | quote }}
     {{- end }}
 spec:
   # Fulcio - Certificate Authority

--- a/charts/rhtas-operator/values.yaml
+++ b/charts/rhtas-operator/values.yaml
@@ -60,6 +60,10 @@ rhtas:
   database:
     create: true
   
+  # Log type configuration for Rekor, Fulcio and Timestamp Authority. Useful for debugging.
+  # Options: prod, dev
+  logType: "prod"
+
   # TUF configuration
   tuf:
     enabled: true


### PR DESCRIPTION
# Description

This change wires log type for **Rekor**, **Fulcio**, and the **Timestamp Authority** into the RHTAS Helm chart so operators can switch between production and development logging when troubleshooting.

# Changes

- `values.yaml`: New `rhtas.logType` value (default "_prod_"), with a short comment describing supported options (prod, dev) and that this is useful for debugging.
- `securesign.yaml`: When `rhtas.logType` is not "_prod_", the chart adds the annotation `rhtas.redhat.com/log-type` on the `SecureSign` resource, set to the configured value. The default prod keeps the manifest unchanged from today (no extra annotation).