### PR TITLE
revert: use wildcard clusterGroupChartVersion to pick up latest clustergroup

### DIFF
--- a/values-global.yaml
+++ b/values-global.yaml
@@ -9,4 +9,4 @@ main:
   clusterGroupName: hub
   multiSourceConfig:
     enabled: true
-    clusterGroupChartVersion: "0.9.47"
+    clusterGroupChartVersion: "0.9.*"


### PR DESCRIPTION
Reverts pinned clusterGroupChartVersion from "0.9.47" back to "0.9.*" so the pattern automatically picks up the latest clustergroup chart.