### PR TITLE
enable ztvp-proxy-ca for all platform types

### DIFF
--- a/charts/ztvp-certificates/values.yaml
+++ b/charts/ztvp-certificates/values.yaml
@@ -119,7 +119,7 @@ configMapName: ztvp-trusted-ca
 # are auto-injected into all workloads via the cluster network operator.
 # Required for workloads that verify TLS of routes (e.g., ACS Central reaching Keycloak).
 proxyCA:
-  enabled: false
+  enabled: true
   configMapName: ztvp-proxy-ca
 
 # Automatic rollout configuration


### PR DESCRIPTION
enable ztvp-proxy-ca for acs-central-services for all platform types. 

Verified on a RHDP AWS setup that the acs-central-services are synced and healthy. 