### PR TITLE
Adding an option to ACS to use cluster CA, not self signed for ACS Central

### DIFF
--- a/charts/acs-central/templates/central-cr.yaml
+++ b/charts/acs-central/templates/central-cr.yaml
@@ -21,6 +21,9 @@ spec:
         port: 443
       route:
         enabled: {{ .Values.central.exposure.route.enabled }}
+        {{- if .Values.central.exposure.route.host }}
+        host: {{ .Values.central.exposure.route.host }}
+        {{- end }}
         {{- if .Values.central.exposure.route.reencrypt.enabled }}
         reencrypt:
           enabled: true

--- a/charts/acs-central/templates/central-cr.yaml
+++ b/charts/acs-central/templates/central-cr.yaml
@@ -21,6 +21,13 @@ spec:
         port: 443
       route:
         enabled: {{ .Values.central.exposure.route.enabled }}
+        {{- if .Values.central.exposure.route.reencrypt.enabled }}
+        reencrypt:
+          enabled: true
+          {{- if .Values.central.exposure.route.reencrypt.host }}
+          host: {{ .Values.central.exposure.route.reencrypt.host }}
+          {{- end }}
+        {{- end }}
 
     {{- if .Values.central.persistence.enabled }}
     persistence:

--- a/charts/acs-central/templates/console-link.yaml
+++ b/charts/acs-central/templates/console-link.yaml
@@ -8,7 +8,11 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "46"
 spec:
+  {{- if .Values.central.exposure.route.reencrypt.enabled }}
+  href: https://central-reencrypt-{{ .Release.Namespace }}.{{ .Values.global.localClusterDomain }}
+  {{- else }}
   href: https://central-{{ .Release.Namespace }}.{{ .Values.global.localClusterDomain }}
+  {{- end }}
   location: ApplicationMenu
   text: Advanced Cluster Security
   applicationMenu:

--- a/charts/acs-central/templates/console-link.yaml
+++ b/charts/acs-central/templates/console-link.yaml
@@ -9,9 +9,17 @@ metadata:
     argocd.argoproj.io/sync-wave: "46"
 spec:
   {{- if .Values.central.exposure.route.reencrypt.enabled }}
-  href: https://central-reencrypt-{{ .Release.Namespace }}.{{ .Values.global.localClusterDomain }}
+  {{- if .Values.central.exposure.route.reencrypt.host }}
+  href: https://{{ .Values.central.exposure.route.reencrypt.host }}
+  {{- else }}
+  href: https://central.{{ .Values.global.localClusterDomain }}
+  {{- end }}
+  {{- else }}
+  {{- if .Values.central.exposure.route.host }}
+  href: https://{{ .Values.central.exposure.route.host }}
   {{- else }}
   href: https://central-{{ .Release.Namespace }}.{{ .Values.global.localClusterDomain }}
+  {{- end }}
   {{- end }}
   location: ApplicationMenu
   text: Advanced Cluster Security

--- a/charts/acs-central/templates/jobs/create-auth-provider.yaml
+++ b/charts/acs-central/templates/jobs/create-auth-provider.yaml
@@ -86,7 +86,7 @@ spec:
                 exit 0
               fi
 
-              ACS_CENTRAL_HOSTNAME="$(oc get route central -n stackrox -o jsonpath='{.spec.host}')"
+              ACS_CENTRAL_HOSTNAME="$(oc get route central-reencrypt -n stackrox -o jsonpath='{.spec.host}' 2>/dev/null || oc get route central -n stackrox -o jsonpath='{.spec.host}')"
               echo "ACS Central hostname: $ACS_CENTRAL_HOSTNAME"
 
               cat > /tmp/oidc-config.json << 'OIDCEOF'

--- a/charts/acs-central/values.yaml
+++ b/charts/acs-central/values.yaml
@@ -73,10 +73,11 @@ central:
   exposure:
     route:
       enabled: true
-      # Use cluster wildcard certificate
       tls:
         enabled: true
         termination: passthrough
+      reencrypt:
+        enabled: true
     loadBalancer:
       enabled: false
 

--- a/charts/acs-central/values.yaml
+++ b/charts/acs-central/values.yaml
@@ -174,7 +174,7 @@ integration:
     # Uses OpenShift CLI tools (curl, oc, jq, etc.)
     jobImage:
       registry: registry.redhat.io
-      repository: openshift4/ose-cli
+      repository: openshift4/ose-cli-rhel9
       tag: latest
       pullPolicy: IfNotPresent
     # Service account used by jobs (init bundle, auth provider, htpasswd)

--- a/charts/acs-central/values.yaml
+++ b/charts/acs-central/values.yaml
@@ -73,11 +73,13 @@ central:
   exposure:
     route:
       enabled: true
+      host: "" # Autogenerate if not specified
       tls:
         enabled: true
         termination: passthrough
       reencrypt:
         enabled: true
+        host: "" # Autogenerate if not specified
     loadBalancer:
       enabled: false
 

--- a/charts/acs-central/values.yaml
+++ b/charts/acs-central/values.yaml
@@ -171,8 +171,8 @@ integration:
     # Container image for the auth provider configuration job
     # Uses OpenShift CLI tools (curl, oc, jq, etc.)
     jobImage:
-      registry: image-registry.openshift-image-registry.svc:5000
-      repository: openshift/cli
+      registry: registry.redhat.io
+      repository: openshift4/ose-cli
       tag: latest
       pullPolicy: IfNotPresent
     # Service account used by jobs (init bundle, auth provider, htpasswd)

--- a/docs/acs-deployment.md
+++ b/docs/acs-deployment.md
@@ -48,6 +48,34 @@ The ACS deployment in the Layered Zero Trust pattern is implemented using:
   - Admission Controller (policy enforcement)
   - Collector (DaemonSet for runtime monitoring)
 
+## Route and TLS Configuration
+
+ACS Central exposes two OpenShift routes with different TLS termination modes:
+
+| Route | TLS Mode | Purpose |
+|---|---|---|
+| `central` | Passthrough | Sensor/SecuredCluster gRPC communication (mTLS) |
+| `central-reencrypt` | Reencrypt | Browser UI access using cluster wildcard certificate |
+
+The **passthrough route is required** for sensor communication. Sensors use
+mutual TLS with certificates from the cluster init bundle, and the RHACS
+operator [explicitly states](https://github.com/stackrox/stackrox/blob/master/operator/api/v1alpha1/central_types.go)
+that the reencrypt route *"should not be used for sensor communication"*
+because the router terminates the sensor's TLS session, breaking mTLS
+authentication.
+
+The **reencrypt route** is enabled by default (`central.exposure.route.reencrypt.enabled: true`)
+so that browser users see the cluster's wildcard certificate instead of
+Central's self-signed certificate. This works on all platforms:
+
+- **Cloud (AWS, Azure, GCP)**: wildcard cert is signed by a public CA — no browser warning
+- **BareMetal / vSphere**: wildcard cert uses the cluster ingress CA — trusted
+  if `ztvp-certificates` has injected it via `proxyCA`
+
+The RHACS operator auto-generates the reencrypt route hostname
+(`central-reencrypt-stackrox.apps.<domain>`). The ConsoleLink and OIDC auth
+provider `uiEndpoint` automatically point to the reencrypt route when enabled.
+
 ## Deployment Workflow
 
 ### Phase 1: Operator Installation (Managed by Pattern Framework)

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -594,6 +594,8 @@ clusterGroup:
     #      value: gp3-csi # Example for AWS
         - name: central.exposure.route.enabled
           value: "true"
+        - name: central.exposure.route.reencrypt.host
+          value: "central.{{ $.Values.global.localClusterDomain }}"
         - name: integration.keycloak.enabled
           value: "true"
         - name: integration.keycloak.realm


### PR DESCRIPTION
With this update Central CR deploys with both route.enabled: true (passthrough) and route.reencrypt.enabled: true. RHACS operator creates both routes automatically. The passthrough route communication is necessary for the Secured cluster and Sensor communication. 

The ConsoleLink points to central-reencrypt-stackrox when reencrypt is enabled (by default).

Keycloak client accepts any hostname, so the redirect to the reencrypt route works on any cluster domain.

This should work with public certs (cloud deployment like AWS) signed by a public CA, and also on BareMetal with self-signed certs. Browsers that trust the org's CA chain see no warning. Even without proxyCA, it's still an improvement because users see the cluster's ingress CA cert (consistent with all other OCP routes) instead of a random ACS-generated self-signed cert.


In the same PR I'm updating the oc cli image, to use the newest public oc cli Red Hat container image instead of OCP internal registry image. 