### PR TITLE
OC CLI image update

### DIFF
--- a/charts/rhtpa-operator/templates/ingress-ca-job.yaml
+++ b/charts/rhtpa-operator/templates/ingress-ca-job.yaml
@@ -93,7 +93,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: extractor
-        image: registry.redhat.io/openshift4/ose-cli:latest
+        image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
         command:
         - /bin/bash
         - -c

--- a/charts/ztvp-certificates/values.yaml
+++ b/charts/ztvp-certificates/values.yaml
@@ -91,7 +91,7 @@ job:
   # Container image for CA extraction
   image:
     registry: registry.redhat.io
-    repository: openshift4/ose-cli
+    repository: openshift4/ose-cli-rhel9
     tag: latest
     pullPolicy: IfNotPresent
   

--- a/scripts/features/registry/option-1-quay.yaml
+++ b/scripts/features/registry/option-1-quay.yaml
@@ -40,7 +40,7 @@ clusterGroup:
         argocd.argoproj.io/sync-wave: "41"
       overrides:
         - name: job.image
-          value: "registry.redhat.io/openshift4/ose-cli:latest"
+          value: "registry.redhat.io/openshift4/ose-cli-rhel9:latest"
 
   merge_into_applications:
     supply-chain:


### PR DESCRIPTION
OC CLI image update, the `openshift4/ose-cli` image is an old OC CLI image used in OCP <=4.15, new oc cli image registry path is `openshift4/ose-cli-rhel9`.