### PR TITLE
feat: add rh-keycloak wrapper chart with short-lived ExternalSecret lifecycle

### DIFF
--- a/charts/rh-keycloak/Chart.yaml
+++ b/charts/rh-keycloak/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: rh-keycloak
+description: ZTVP Keycloak deployment — wraps the rhbk chart with short-lived ExternalSecret lifecycle via ArgoCD hooks
+type: application
+version: 0.1.0
+dependencies:
+  - name: rhbk
+    version: ">=0.0.12"
+    repository: "oci://quay.io/validatedpatterns"
+maintainers:
+  - name: Zero Trust Validated Patterns Team
+    email: ztvp-arch-group@redhat.com
+keywords:
+  - keycloak
+  - rhbk
+  - zero-trust
+  - pattern

--- a/charts/rh-keycloak/templates/cleanup-keycloak-users.yaml
+++ b/charts/rh-keycloak/templates/cleanup-keycloak-users.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.cleanup.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cleanup-keycloak-users
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cleanup-keycloak-users
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cleanup-keycloak-users
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cleanup-keycloak-users
+subjects:
+- kind: ServiceAccount
+  name: cleanup-keycloak-users
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cleanup-keycloak-users
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      labels:
+        app: cleanup-keycloak-users
+    spec:
+      serviceAccountName: cleanup-keycloak-users
+      restartPolicy: Never
+      containers:
+      - name: cleanup
+        image: {{ .Values.cleanup.image }}
+        command:
+        - /bin/bash
+        - -ce
+        - |
+          oc delete secret -l "validatedpatterns.io/cleanup=delete" -n "{{ .Release.Namespace }}" --ignore-not-found
+          echo "Cleanup complete."
+{{- end }}

--- a/charts/rh-keycloak/templates/cleanup-network-policy.yaml
+++ b/charts/rh-keycloak/templates/cleanup-network-policy.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.cleanup.enabled (eq (.Values.rhbk.defaultDenyNetworkPolicy.enabled | toString) "true") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cleanup-keycloak-users-netpol
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  podSelector:
+    matchLabels:
+      app: cleanup-keycloak-users
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+  - ports:
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/charts/rh-keycloak/values.yaml
+++ b/charts/rh-keycloak/values.yaml
@@ -1,0 +1,24 @@
+# PostSync Job deletes the keycloak-users Secret after realm import consumes it.
+cleanup:
+  enabled: true
+  image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
+
+# Values passed through to the rhbk subchart.
+# The keycloakUsers ExternalSecret uses a short-lived ArgoCD hook lifecycle:
+# - Created during Sync, deleted by HookSucceeded
+# - Secret survives via creationPolicy: Orphan + deletionPolicy: Retain
+# - PostSync Job removes the Secret for security hygiene
+rhbk:
+  externalSecrets:
+    keycloakUsers:
+      creationPolicy: "Orphan"
+      deletionPolicy: "Retain"
+      refreshPolicy: "OnChange"
+      metadata:
+        annotations:
+          argocd.argoproj.io/hook: Sync
+          argocd.argoproj.io/hook-delete-policy: HookSucceeded
+          argocd.argoproj.io/sync-options: PrunePropagationPolicy=orphan
+      targetMetadata:
+        labels:
+          validatedpatterns.io/cleanup: delete

--- a/overrides/values-keycloak-network-policy.yaml
+++ b/overrides/values-keycloak-network-policy.yaml
@@ -1,153 +1,154 @@
-defaultDenyNetworkPolicy:
-  enabled: true
-
-networkPolicy:
-  keycloak:
+rhbk:
+  defaultDenyNetworkPolicy:
     enabled: true
-    egress:
-      # DNS resolution via CoreDNS — OCP uses port 5353
-      - ports:
-        - protocol: UDP
-          port: 5353
-        - protocol: TCP
-          port: 5353
-        to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-dns
-      # PostgreSQL backend database
-      - ports:
-        - protocol: TCP
-          port: 5432
-        to:
-        - podSelector:
-            matchLabels:
-              app: postgresql-db
-      # JGroups cluster discovery and failure detection (multi-instance clustering)
-      - ports:
-        - protocol: TCP
-          port: 7800
-        - protocol: TCP
-          port: 57800
-        to:
-        - podSelector:
-            matchLabels:
-              app: keycloak
-              app.kubernetes.io/instance: keycloak
-              app.kubernetes.io/managed-by: keycloak-operator
-      # Kubernetes API server — JDBC_PING discovery reads endpoints
-      # Endpoints are node IPs after DNAT, port-only rule required
-      - ports:
-        - protocol: TCP
-          port: 6443
-      # SPIRE OIDC discovery provider — Keycloak fetches JWKS for federated
-      # client auth (spiffe feature). Traffic goes via the OCP router external
-      # IP, port-only rule required
-      - ports:
-        - protocol: TCP
-          port: 443
 
-  realmImport:
-    enabled: true
-    podSelector:
-      app: keycloak-realm-import
-    egress:
-      # DNS resolution via CoreDNS
-      - ports:
-        - protocol: UDP
-          port: 5353
-        - protocol: TCP
-          port: 5353
-        to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-dns
-      # PostgreSQL — realm import writes realm data to the database
-      - ports:
-        - protocol: TCP
-          port: 5432
-        to:
-        - podSelector:
-            matchLabels:
-              app: postgresql-db
-      # Kubernetes API server — reads secrets referenced in KeycloakRealmImport CR
-      - ports:
-        - protocol: TCP
-          port: 6443
-      # Keycloak HTTPS API — admin API calls during realm import
-      - ports:
-        - protocol: TCP
-          port: 8443
-        to:
-        - podSelector:
-            matchLabels:
-              app: keycloak
-              app.kubernetes.io/instance: keycloak
-              app.kubernetes.io/managed-by: keycloak-operator
+  networkPolicy:
+    keycloak:
+      enabled: true
+      egress:
+        # DNS resolution via CoreDNS — OCP uses port 5353
+        - ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+          to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+        # PostgreSQL backend database
+        - ports:
+          - protocol: TCP
+            port: 5432
+          to:
+          - podSelector:
+              matchLabels:
+                app: postgresql-db
+        # JGroups cluster discovery and failure detection (multi-instance clustering)
+        - ports:
+          - protocol: TCP
+            port: 7800
+          - protocol: TCP
+            port: 57800
+          to:
+          - podSelector:
+              matchLabels:
+                app: keycloak
+                app.kubernetes.io/instance: keycloak
+                app.kubernetes.io/managed-by: keycloak-operator
+        # Kubernetes API server — JDBC_PING discovery reads endpoints
+        # Endpoints are node IPs after DNAT, port-only rule required
+        - ports:
+          - protocol: TCP
+            port: 6443
+        # SPIRE OIDC discovery provider — Keycloak fetches JWKS for federated
+        # client auth (spiffe feature). Traffic goes via the OCP router external
+        # IP, port-only rule required
+        - ports:
+          - protocol: TCP
+            port: 443
 
-  postgresql:
-    enabled: true
-    ingress:
-      # Accept connections from Keycloak pods and realm import jobs
-      - ports:
-        - protocol: TCP
-          port: 5432
-        from:
-        - podSelector:
-            matchLabels:
-              app: keycloak
-              app.kubernetes.io/instance: keycloak
-              app.kubernetes.io/managed-by: keycloak-operator
-        - podSelector:
-            matchLabels:
-              app: keycloak-realm-import
-    egress:
-      # DNS resolution via CoreDNS
-      - ports:
-        - protocol: UDP
-          port: 5353
-        - protocol: TCP
-          port: 5353
-        to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-dns
+    realmImport:
+      enabled: true
+      podSelector:
+        app: keycloak-realm-import
+      egress:
+        # DNS resolution via CoreDNS
+        - ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+          to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+        # PostgreSQL — realm import writes realm data to the database
+        - ports:
+          - protocol: TCP
+            port: 5432
+          to:
+          - podSelector:
+              matchLabels:
+                app: postgresql-db
+        # Kubernetes API server — reads secrets referenced in KeycloakRealmImport CR
+        - ports:
+          - protocol: TCP
+            port: 6443
+        # Keycloak HTTPS API — admin API calls during realm import
+        - ports:
+          - protocol: TCP
+            port: 8443
+          to:
+          - podSelector:
+              matchLabels:
+                app: keycloak
+                app.kubernetes.io/instance: keycloak
+                app.kubernetes.io/managed-by: keycloak-operator
 
-  operator:
-    enabled: true
-    # No ingress rules — operator only initiates outbound connections
-    egress:
-      # DNS resolution via CoreDNS
-      - ports:
-        - protocol: UDP
-          port: 5353
-        - protocol: TCP
-          port: 5353
-        to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-dns
-      # Kubernetes API server — operator watches CRs and manages resources
-      - ports:
-        - protocol: TCP
-          port: 6443
-      # Keycloak management endpoint — health checks and reconciliation
-      - ports:
-        - protocol: TCP
-          port: 9000
-        to:
-        - podSelector:
-            matchLabels:
-              app: keycloak
-              app.kubernetes.io/instance: keycloak
-              app.kubernetes.io/managed-by: keycloak-operator
-      # Keycloak HTTPS API — admin API calls during realm/client reconciliation
-      - ports:
-        - protocol: TCP
-          port: 8443
-        to:
-        - podSelector:
-            matchLabels:
-              app: keycloak
-              app.kubernetes.io/instance: keycloak
-              app.kubernetes.io/managed-by: keycloak-operator
+    postgresql:
+      enabled: true
+      ingress:
+        # Accept connections from Keycloak pods and realm import jobs
+        - ports:
+          - protocol: TCP
+            port: 5432
+          from:
+          - podSelector:
+              matchLabels:
+                app: keycloak
+                app.kubernetes.io/instance: keycloak
+                app.kubernetes.io/managed-by: keycloak-operator
+          - podSelector:
+              matchLabels:
+                app: keycloak-realm-import
+      egress:
+        # DNS resolution via CoreDNS
+        - ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+          to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+
+    operator:
+      enabled: true
+      # No ingress rules — operator only initiates outbound connections
+      egress:
+        # DNS resolution via CoreDNS
+        - ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+          to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+        # Kubernetes API server — operator watches CRs and manages resources
+        - ports:
+          - protocol: TCP
+            port: 6443
+        # Keycloak management endpoint — health checks and reconciliation
+        - ports:
+          - protocol: TCP
+            port: 9000
+          to:
+          - podSelector:
+              matchLabels:
+                app: keycloak
+                app.kubernetes.io/instance: keycloak
+                app.kubernetes.io/managed-by: keycloak-operator
+        # Keycloak HTTPS API — admin API calls during realm/client reconciliation
+        - ports:
+          - protocol: TCP
+            port: 8443
+          to:
+          - podSelector:
+              matchLabels:
+                app: keycloak
+                app.kubernetes.io/instance: keycloak
+                app.kubernetes.io/managed-by: keycloak-operator

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -443,18 +443,18 @@ clusterGroup:
       name: rh-keycloak
       namespace: keycloak-system
       argoProject: hub
-      chart: rhbk
-      chartVersion: 0.0.*
+      path: charts/rh-keycloak
       extraValueFiles:
         - /overrides/values-keycloak-network-policy.yaml
       annotations:
         argocd.argoproj.io/sync-wave: "35"
-      # SPIFFE Identity Provider is enabled by default in the chart.
+      # SPIFFE Identity Provider is enabled by default in the rhbk subchart.
       # Override issuer/jwksUrl only if auto-generated values from cluster domain are not suitable.
+      # Note: overrides must use the rhbk. prefix to reach the subchart.
       # overrides:
-        # - name: keycloak.spiffeIdentityProvider.config.config.issuer
+        # - name: rhbk.keycloak.spiffeIdentityProvider.config.config.issuer
         #   value: "spiffe://apps.example.com"
-        # - name: keycloak.spiffeIdentityProvider.config.config.jwksUrl
+        # - name: rhbk.keycloak.spiffeIdentityProvider.config.config.jwksUrl
         #   value: "https://spire-spiffe-oidc-discovery-provider.apps.example.com/keys"
     rh-cert-manager:
       name: rh-cert-manager


### PR DESCRIPTION
## Summary

- Add a wrapper chart (`charts/rh-keycloak`) that consumes the `rhbk` chart as a dependency and configures the `keycloakUsers` ExternalSecret with a short-lived ArgoCD hook lifecycle
- Switch `values-hub.yaml` from the remote `rhbk` chart to the local `rh-keycloak` wrapper chart path
- A simplified PostSync Job deletes the `keycloak-users` Secret after realm import for security hygiene

## How it works

The `keycloakUsers` ExternalSecret is annotated as an ArgoCD **Sync hook** with `HookSucceeded` delete policy and ESO resource policies:

1. ArgoCD creates the ExternalSecret during sync (hook: Sync)
2. ESO fetches user passwords from Vault and creates the `keycloak-users` Secret (`creationPolicy: Orphan`)
3. Keycloak realm import reads the Secret and stores credentials in PostgreSQL
4. ArgoCD deletes the ExternalSecret after it reaches Ready (`HookSucceeded` + `PrunePropagationPolicy=orphan`)
5. The Secret persists (`deletionPolicy: Retain`) — ESO can no longer overwrite it
6. A PostSync Job deletes the `keycloak-users` Secret (no longer needed, contains initial passwords)

A conditional NetworkPolicy for the cleanup Job is included for environments with default-deny policies.

## Dependencies

- **Requires rhbk-chart >= 0.0.12** — lifecycle management for ExternalSecrets (tagged and published)