### PR TITLE
fix: bump ACM operator channel to release-2.16

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -115,7 +115,7 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.15
+      channel: release-2.16
       catalogSource: redhat-operators
     eso:
       name: openshift-external-secrets-operator


### PR DESCRIPTION
## Summary

- Bump the Advanced Cluster Management (ACM) operator subscription channel from `release-2.15` to `release-2.16` in `values-hub.yaml`
- ACM 2.16 is the current release; keeping the channel pinned to 2.15 prevents clusters from receiving updates

## Test plan

- [ ] Verify the ACM operator subscription updates to the `release-2.16` channel
- [ ] Verify applications can be installed properly